### PR TITLE
add staging environment with persistent volume for tsdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,29 @@ Ref. https://cloud.google.com/kubernetes-engine/docs/how-to/role-based-access-co
 TODO: make it yaml configuration if it is possible.
 
 ## Deploy Promethus Server to GKE
-### Deploy an Environment
+### Deploy Development Environment
 ```
 ikustomize build overlays/dev | kubectl apply -f -
+```
+### Deploy Staging Environment
+```
+ikustomize build overlays/stg | kubectl apply -f -
 ```
 
 ## Debugging and Understanding What is Happening on k8s/GKE
 The following commands sometimes expect `NAMESPACE` and `ENVIRONMENT` variables.
 
-### development environment
+### Development Environment
 - `NAMESPACE=dev-monitoring`
 - `ENVIRONMENT=development`
 
+### Staging Environment
+- `NAMESPACE=stg-monitoring`
+- `ENVIRONMENT=staging`
+
 ## Check Rsources
 ```
-kubectl get pods,deployments,services,configmaps,namespaces,serviceaccount --show-labels --namespace ${NAMESPACE}
+kubectl get pods,deployments,services,configmaps,persistentvolumeclaim,storageclass,namespaces,serviceaccount --show-labels --namespace ${NAMESPACE}
 ```
 
 ## Enjoy Observing Rolling Update during the Deployment

--- a/base/configmap.yaml
+++ b/base/configmap.yaml
@@ -63,76 +63,76 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
 
-    - job_name: 'kubernetes-service-endpoints'
-      kubernetes_sd_configs:
-      - role: endpoints
-
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        action: replace
-        target_label: kubernetes_name
-
-    - job_name: 'kubernetes-services'
-      kubernetes_sd_configs:
-      - role: service
-
-      metrics_path: /probe
-      params:
-        module: [http_2xx]
-
-      relabel_configs:
-      - source_labels: [__address__]
-        target_label: __param_target
-      - target_label: __address__
-        replacement: blackbox-exporter.example.com:9115
-      - source_labels: [__param_target]
-        target_label: instance
-      - action: labelmap
-        regex: __meta_kubernetes_service_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_service_name]
-        target_label: kubernetes_name
-
-    - job_name: 'kubernetes-ingresses'
-      kubernetes_sd_configs:
-      - role: ingress
-
-      metrics_path: /probe
-      params:
-        module: [http_2xx]
-
-      relabel_configs:
-      - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]
-        regex: (.+);(.+);(.+)
-        replacement: ${1}://${2}${3}
-        target_label: __param_target
-      - target_label: __address__
-        replacement: blackbox-exporter.example.com:9115
-      - source_labels: [__param_target]
-        target_label: instance
-      - action: labelmap
-        regex: __meta_kubernetes_ingress_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_ingress_name]
-        target_label: kubernetes_name
-
-    - job_name: 'kubernetes-pods'
-      kubernetes_sd_configs:
-      - role: pod
-
-      relabel_configs:
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
-      - source_labels: [__meta_kubernetes_namespace]
-        action: replace
-        target_label: kubernetes_namespace
-      - source_labels: [__meta_kubernetes_pod_name]
-        action: replace
-        target_label: kubernetes_pod_name
+#    - job_name: 'kubernetes-service-endpoints'
+#      kubernetes_sd_configs:
+#      - role: endpoints
+#
+#      relabel_configs:
+#      - action: labelmap
+#        regex: __meta_kubernetes_service_label_(.+)
+#      - source_labels: [__meta_kubernetes_namespace]
+#        action: replace
+#        target_label: kubernetes_namespace
+#      - source_labels: [__meta_kubernetes_service_name]
+#        action: replace
+#        target_label: kubernetes_name
+#
+#    - job_name: 'kubernetes-services'
+#      kubernetes_sd_configs:
+#      - role: service
+#
+#      metrics_path: /probe
+#      params:
+#        module: [http_2xx]
+#
+#      relabel_configs:
+#      - source_labels: [__address__]
+#        target_label: __param_target
+#      - target_label: __address__
+#        replacement: blackbox-exporter.example.com:9115
+#      - source_labels: [__param_target]
+#        target_label: instance
+#      - action: labelmap
+#        regex: __meta_kubernetes_service_label_(.+)
+#      - source_labels: [__meta_kubernetes_namespace]
+#        target_label: kubernetes_namespace
+#      - source_labels: [__meta_kubernetes_service_name]
+#        target_label: kubernetes_name
+#
+#    - job_name: 'kubernetes-ingresses'
+#      kubernetes_sd_configs:
+#      - role: ingress
+#
+#      metrics_path: /probe
+#      params:
+#        module: [http_2xx]
+#
+#      relabel_configs:
+#      - source_labels: [__meta_kubernetes_ingress_scheme,__address__,__meta_kubernetes_ingress_path]
+#        regex: (.+);(.+);(.+)
+#        replacement: ${1}://${2}${3}
+#        target_label: __param_target
+#      - target_label: __address__
+#        replacement: blackbox-exporter.example.com:9115
+#      - source_labels: [__param_target]
+#        target_label: instance
+#      - action: labelmap
+#        regex: __meta_kubernetes_ingress_label_(.+)
+#      - source_labels: [__meta_kubernetes_namespace]
+#        target_label: kubernetes_namespace
+#      - source_labels: [__meta_kubernetes_ingress_name]
+#        target_label: kubernetes_name
+#
+#    - job_name: 'kubernetes-pods'
+#      kubernetes_sd_configs:
+#      - role: pod
+#
+#      relabel_configs:
+#      - action: labelmap
+#        regex: __meta_kubernetes_pod_label_(.+)
+#      - source_labels: [__meta_kubernetes_namespace]
+#        action: replace
+#        target_label: kubernetes_namespace
+#      - source_labels: [__meta_kubernetes_pod_name]
+#        action: replace
+#        target_label: kubernetes_pod_name

--- a/base/deployment.yaml
+++ b/base/deployment.yaml
@@ -53,4 +53,8 @@ spec:
             name: prometheus-server-config
             defaultMode: 420
         - name: prometheus-storage-tsdb-volume
-          emptyDir: {}
+          # NOTE: Depends on environment
+      securityContext: # To avoid "open /prometheus/lock: permission denied"
+        fsGroup: 2000
+        runAsNonRoot: true
+        runAsUser: 1000

--- a/overlays/stg/clusterRole.yaml
+++ b/overlays/stg/clusterRole.yaml
@@ -1,0 +1,9 @@
+# NOTE: This patch is not necessary after merging https://github.com/kubernetes-sigs/kustomize/pull/166
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: ex-gcp-k8s-prometheus
+subjects:
+- kind: ServiceAccount
+  name: ex-gcp-k8s-prometheus
+  namespace: stg-monitoring

--- a/overlays/stg/deployment.yaml
+++ b/overlays/stg/deployment.yaml
@@ -8,9 +8,10 @@ spec:
       containers:
       - name: prometheus
         resources:
-          limits: # If the node is g1-small and limit requests are too low, the pod status becomes 'OOMKilled'.
+          limits:
             cpu: 150m
             memory: 150Mi
       volumes:
         - name: prometheus-storage-tsdb-volume
-          emptyDir: {}
+          persistentVolumeClaim:
+            claimName: prometheus-tsdb-storage

--- a/overlays/stg/kustomization.yaml
+++ b/overlays/stg/kustomization.yaml
@@ -1,0 +1,16 @@
+namespace: stg-monitoring
+namePrefix: stg-
+commonLabels:
+  variant: staging
+bases:
+- ../../base
+patches:
+- deployment.yaml
+- clusterRole.yaml
+resources:
+- volume.yaml
+configMapGenerator:
+- name: prometheus-server-config
+  behavior: merge
+  literals:
+    - tsdbRetention=48h

--- a/overlays/stg/volume.yaml
+++ b/overlays/stg/volume.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometheus-tsdb-storage
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+  storageClassName: stg-prometheus-storage-class # kustomize does not supplies prefix.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: prometheus-storage-class
+provisioner: kubernetes.io/gce-pd
+reclaimPolicy: Delete
+parameters:
+  type: pd-standard
+  zones: asia-northeast1-a
+  replication-type: none


### PR DESCRIPTION
- add staging environment with persistent volume for tsdb
- patch `emptyDir` for `dev` to switch it between `dev` and `stg`
    - NOTE: Currently it can not have `emptyDir` in `base` as a default volume setting (kustomize just add patch instead of replacing `emptyDir `)
- disable service related scrapings until I add `kind: service`